### PR TITLE
feat: add SearchUsers method to user service (FIN-271)

### DIFF
--- a/users.go
+++ b/users.go
@@ -13,6 +13,7 @@ type UpdateUserResponse = usersv1.UpdateUserResponse
 type GetUserResponse = usersv1.GetUserResponse
 type ListOrganizationUsersResponse = usersv1.ListOrganizationUsersResponse
 type ListUsersResponse = usersv1.ListUsersResponse
+type SearchUsersResponse = usersv1.SearchUsersResponse
 type CreateMembershipResponse = usersv1.CreateMembershipResponse
 type UpdateMembershipResponse = usersv1.UpdateMembershipResponse
 type ListUserRolesResponse = usersv1.ListUserRolesResponse
@@ -24,11 +25,18 @@ type ListUsersOptions struct {
 	PageToken string
 }
 
+// SearchUsersOptions represents optional parameters for searching users
+type SearchUsersOptions struct {
+	PageSize  uint32
+	PageToken string
+}
+
 type UserService interface {
 	CreateUserAndMembership(ctx context.Context, organizationId string, user *usersv1.CreateUser, sendInvitationEmail bool) (*CreateUserAndMembershipResponse, error)
 	UpdateUser(ctx context.Context, userId string, updateUser *usersv1.UpdateUser) (*UpdateUserResponse, error)
 	GetUser(ctx context.Context, userId string) (*GetUserResponse, error)
 	ListUsers(ctx context.Context, options *ListUsersOptions) (*ListUsersResponse, error)
+	SearchUsers(ctx context.Context, query string, options *SearchUsersOptions) (*SearchUsersResponse, error)
 	ListOrganizationUsers(ctx context.Context, organizationId string, options *ListUsersOptions) (*ListOrganizationUsersResponse, error)
 	DeleteUser(ctx context.Context, userId string) error
 	CreateMembership(ctx context.Context, organizationId string, userId string, membership *usersv1.CreateMembership, sendInvitationEmail bool) (*CreateMembershipResponse, error)
@@ -103,6 +111,24 @@ func (u *userService) ListUsers(ctx context.Context, options *ListUsersOptions) 
 	return newConnectExecuter(
 		u.coreClient,
 		u.client.ListUsers,
+		request,
+	).exec(ctx)
+}
+
+// SearchUsers searches users across the environment using a query string with optional pagination.
+// Pass nil options to use server defaults.
+func (u *userService) SearchUsers(ctx context.Context, query string, options *SearchUsersOptions) (*SearchUsersResponse, error) {
+	request := &usersv1.SearchUsersRequest{
+		Query: query,
+	}
+	if options != nil {
+		request.PageSize = options.PageSize
+		request.PageToken = options.PageToken
+	}
+
+	return newConnectExecuter(
+		u.coreClient,
+		u.client.SearchUsers,
 		request,
 	).exec(ctx)
 }


### PR DESCRIPTION
## Summary
- Adds `SearchUsers(ctx, query, *SearchUsersOptions)` to the `UserService` interface, wrapping the already-generated `SearchUsers` Connect RPC.
- Introduces `SearchUsersOptions` (PageSize / PageToken) and a `SearchUsersResponse` type alias to mirror the existing `ListUsers` shape.

Closes FIN-271.

## Test plan
- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] Manual integration test: `client.User().SearchUsers(ctx, "john", &scalekit.SearchUsersOptions{PageSize: 10})`

<!-- generated-by-cyrus -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Users can now search for other users in the system with pagination support for efficient result navigation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/scalekit-sdk-go/pull/72)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->