### PR TITLE
feat(users): add external_id lookup methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/scalekit-inc/scalekit-sdk-go/v2
 
 go 1.25.0
 
-toolchain go1.25.10
+toolchain go1.25.11
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.2-20240717164558-a6c49f84cc0f.2

--- a/test/users_test.go
+++ b/test/users_test.go
@@ -217,6 +217,101 @@ func TestUser_MembershipOperations(t *testing.T) {
 	assert.Equal(t, userId, userAfterDelete.GetUser().GetId())
 }
 
+func TestUserExternalIdOperations(t *testing.T) {
+	ctx := context.Background()
+
+	// Two orgs: user is initially a member of org1, then added to org2 via external ID
+	orgId1 := createOrg(t, ctx, TestOrgName, UniqueSuffix())
+	defer DeleteTestOrganization(t, ctx, orgId1)
+	orgId2 := createOrg(t, ctx, "Acme Corp 2", UniqueSuffix())
+	defer DeleteTestOrganization(t, ctx, orgId2)
+
+	// Unique external ID for this test run
+	extID := fmt.Sprintf("ext-user-%d", time.Now().UnixNano()/1e6)
+	uniqueEmail := fmt.Sprintf("extid.user.%d@example.com", time.Now().UnixNano()/1e6)
+
+	// Create user with an external_id
+	newUser := &users.CreateUser{
+		Email:      uniqueEmail,
+		ExternalId: &extID,
+		Metadata:   map[string]string{"source": "external_id_test"},
+	}
+	createdUser, err := client.User().CreateUserAndMembership(ctx, orgId1, newUser, false)
+	require.NoError(t, err)
+	require.NotNil(t, createdUser)
+	require.NotNil(t, createdUser.GetUser())
+	userId := createdUser.GetUser().GetId()
+	require.NotEmpty(t, userId)
+	// Cleanup: delete the user after the test (best-effort)
+	defer func() { _ = client.User().DeleteUser(ctx, userId) }()
+
+	// 1. GetUserByExternalId
+	gotUser, err := client.User().GetUserByExternalId(ctx, extID)
+	require.NoError(t, err)
+	require.NotNil(t, gotUser)
+	require.NotNil(t, gotUser.GetUser())
+	assert.Equal(t, userId, gotUser.GetUser().GetId())
+	assert.Equal(t, extID, gotUser.GetUser().GetExternalId())
+
+	// 2. UpdateUserByExternalId
+	givenName := "External"
+	familyName := "User"
+	updateReq := &users.UpdateUser{
+		UserProfile: &users.UpdateUserProfile{
+			GivenName:  &givenName,
+			FamilyName: &familyName,
+		},
+	}
+	updatedUser, err := client.User().UpdateUserByExternalId(ctx, extID, updateReq)
+	require.NoError(t, err)
+	require.NotNil(t, updatedUser)
+	require.NotNil(t, updatedUser.GetUser().GetUserProfile())
+	assert.Equal(t, "External", updatedUser.GetUser().GetUserProfile().GetGivenName())
+	assert.Equal(t, "User", updatedUser.GetUser().GetUserProfile().GetFamilyName())
+
+	// 3. CreateMembershipByExternalId — add user to org2
+	membership := &users.CreateMembership{
+		Roles: []*commons.Role{
+			{Name: "admin"},
+		},
+		Metadata: map[string]string{"membership_type": "external_id_test"},
+	}
+	membershipResp, err := client.User().CreateMembershipByExternalId(ctx, orgId2, extID, membership, false)
+	require.NoError(t, err)
+	require.NotNil(t, membershipResp)
+	require.NotNil(t, membershipResp.GetUser())
+	assert.Equal(t, userId, membershipResp.GetUser().GetId())
+
+	// 4. UpdateMembershipByExternalId — change role to member
+	updateMembership := &users.UpdateMembership{
+		Roles: []*commons.Role{
+			{Name: "member"},
+		},
+		Metadata: map[string]string{"membership_type": "updated_external_id_test"},
+	}
+	updatedMembershipResp, err := client.User().UpdateMembershipByExternalId(ctx, orgId2, extID, updateMembership)
+	require.NoError(t, err)
+	require.NotNil(t, updatedMembershipResp)
+
+	// 5. DeleteMembershipByExternalId — remove from org2
+	err = client.User().DeleteMembershipByExternalId(ctx, orgId2, extID, false)
+	require.NoError(t, err)
+
+	// Verify user still exists after membership deletion
+	userAfterMembershipDelete, err := client.User().GetUser(ctx, userId)
+	require.NoError(t, err)
+	require.NotNil(t, userAfterMembershipDelete)
+	assert.Equal(t, userId, userAfterMembershipDelete.GetUser().GetId())
+
+	// 6. DeleteUserByExternalId
+	err = client.User().DeleteUserByExternalId(ctx, extID)
+	require.NoError(t, err)
+
+	// Verify user is gone — subsequent GetUser should return an error
+	_, err = client.User().GetUser(ctx, userId)
+	assert.Error(t, err, "expected error after deleting user by external ID")
+}
+
 func TestUser_ResendInvite(t *testing.T) {
 	ctx := context.Background()
 	orgId := createOrg(t, ctx, TestOrgName, UniqueSuffix())

--- a/users.go
+++ b/users.go
@@ -8,15 +8,17 @@ import (
 )
 
 // Type aliases for response types
-type CreateUserAndMembershipResponse = usersv1.CreateUserAndMembershipResponse
-type UpdateUserResponse = usersv1.UpdateUserResponse
-type GetUserResponse = usersv1.GetUserResponse
-type ListOrganizationUsersResponse = usersv1.ListOrganizationUsersResponse
-type ListUsersResponse = usersv1.ListUsersResponse
-type CreateMembershipResponse = usersv1.CreateMembershipResponse
-type UpdateMembershipResponse = usersv1.UpdateMembershipResponse
-type ListUserRolesResponse = usersv1.ListUserRolesResponse
-type ListUserPermissionsResponse = usersv1.ListUserPermissionsResponse
+type (
+	CreateUserAndMembershipResponse = usersv1.CreateUserAndMembershipResponse
+	UpdateUserResponse              = usersv1.UpdateUserResponse
+	GetUserResponse                 = usersv1.GetUserResponse
+	ListOrganizationUsersResponse   = usersv1.ListOrganizationUsersResponse
+	ListUsersResponse               = usersv1.ListUsersResponse
+	CreateMembershipResponse        = usersv1.CreateMembershipResponse
+	UpdateMembershipResponse        = usersv1.UpdateMembershipResponse
+	ListUserRolesResponse           = usersv1.ListUserRolesResponse
+	ListUserPermissionsResponse     = usersv1.ListUserPermissionsResponse
+)
 
 // ListUsersOptions represents optional parameters for listing users
 type ListUsersOptions struct {
@@ -28,12 +30,18 @@ type UserService interface {
 	CreateUserAndMembership(ctx context.Context, organizationId string, user *usersv1.CreateUser, sendInvitationEmail bool) (*CreateUserAndMembershipResponse, error)
 	UpdateUser(ctx context.Context, userId string, updateUser *usersv1.UpdateUser) (*UpdateUserResponse, error)
 	GetUser(ctx context.Context, userId string) (*GetUserResponse, error)
+	GetUserByExternalId(ctx context.Context, externalId string) (*GetUserResponse, error)
+	UpdateUserByExternalId(ctx context.Context, externalId string, updateUser *usersv1.UpdateUser) (*UpdateUserResponse, error)
+	DeleteUserByExternalId(ctx context.Context, externalId string) error
 	ListUsers(ctx context.Context, options *ListUsersOptions) (*ListUsersResponse, error)
 	ListOrganizationUsers(ctx context.Context, organizationId string, options *ListUsersOptions) (*ListOrganizationUsersResponse, error)
 	DeleteUser(ctx context.Context, userId string) error
 	CreateMembership(ctx context.Context, organizationId string, userId string, membership *usersv1.CreateMembership, sendInvitationEmail bool) (*CreateMembershipResponse, error)
 	UpdateMembership(ctx context.Context, organizationId string, userId string, membership *usersv1.UpdateMembership) (*UpdateMembershipResponse, error)
 	DeleteMembership(ctx context.Context, organizationId string, userId string, cascade bool) error
+	CreateMembershipByExternalId(ctx context.Context, organizationId string, externalId string, membership *usersv1.CreateMembership, sendInvitationEmail bool) (*CreateMembershipResponse, error)
+	UpdateMembershipByExternalId(ctx context.Context, organizationId string, externalId string, membership *usersv1.UpdateMembership) (*UpdateMembershipResponse, error)
+	DeleteMembershipByExternalId(ctx context.Context, organizationId string, externalId string, cascade bool) error
 	ResendInvite(ctx context.Context, organizationId string, userId string) (*usersv1.ResendInviteResponse, error)
 	ListUserRoles(ctx context.Context, organizationId string, userId string) (*ListUserRolesResponse, error)
 	ListUserPermissions(ctx context.Context, organizationId string, userId string) (*ListUserPermissionsResponse, error)
@@ -89,6 +97,45 @@ func (u *userService) GetUser(ctx context.Context, userId string) (*GetUserRespo
 		u.client.GetUser,
 		request,
 	).exec(ctx)
+}
+
+// GetUserByExternalId retrieves a user by their external ID
+func (u *userService) GetUserByExternalId(ctx context.Context, externalId string) (*GetUserResponse, error) {
+	request := &usersv1.GetUserRequest{}
+	request.Identities = &usersv1.GetUserRequest_ExternalId{ExternalId: externalId}
+
+	return newConnectExecuter(
+		u.coreClient,
+		u.client.GetUser,
+		request,
+	).exec(ctx)
+}
+
+// UpdateUserByExternalId updates an existing user identified by their external ID
+func (u *userService) UpdateUserByExternalId(ctx context.Context, externalId string, updateUser *usersv1.UpdateUser) (*UpdateUserResponse, error) {
+	request := &usersv1.UpdateUserRequest{
+		User: updateUser,
+	}
+	request.Identities = &usersv1.UpdateUserRequest_ExternalId{ExternalId: externalId}
+
+	return newConnectExecuter(
+		u.coreClient,
+		u.client.UpdateUser,
+		request,
+	).exec(ctx)
+}
+
+// DeleteUserByExternalId deletes a user identified by their external ID
+func (u *userService) DeleteUserByExternalId(ctx context.Context, externalId string) error {
+	request := &usersv1.DeleteUserRequest{}
+	request.Identities = &usersv1.DeleteUserRequest_ExternalId{ExternalId: externalId}
+
+	_, err := newConnectExecuter(
+		u.coreClient,
+		u.client.DeleteUser,
+		request,
+	).exec(ctx)
+	return err
 }
 
 // ListUsers retrieves all users across the environment with optional pagination.
@@ -177,6 +224,55 @@ func (u *userService) DeleteMembership(ctx context.Context, organizationId strin
 		Cascade:        &cascade,
 	}
 	request.Identities = &usersv1.DeleteMembershipRequest_Id{Id: userId}
+
+	_, err := newConnectExecuter(
+		u.coreClient,
+		u.client.DeleteMembership,
+		request,
+	).exec(ctx)
+	return err
+}
+
+// CreateMembershipByExternalId creates a membership for a user (identified by external ID) in an organization
+func (u *userService) CreateMembershipByExternalId(ctx context.Context, organizationId string, externalId string, membership *usersv1.CreateMembership, sendInvitationEmail bool) (*CreateMembershipResponse, error) {
+	request := &usersv1.CreateMembershipRequest{
+		OrganizationId:      organizationId,
+		Membership:          membership,
+		SendInvitationEmail: &sendInvitationEmail,
+	}
+	request.Identities = &usersv1.CreateMembershipRequest_ExternalId{ExternalId: externalId}
+
+	return newConnectExecuter(
+		u.coreClient,
+		u.client.CreateMembership,
+		request,
+	).exec(ctx)
+}
+
+// UpdateMembershipByExternalId updates a user's membership (identified by external ID) in an organization
+func (u *userService) UpdateMembershipByExternalId(ctx context.Context, organizationId string, externalId string, membership *usersv1.UpdateMembership) (*UpdateMembershipResponse, error) {
+	request := &usersv1.UpdateMembershipRequest{
+		OrganizationId: organizationId,
+		Membership:     membership,
+	}
+	request.Identities = &usersv1.UpdateMembershipRequest_ExternalId{ExternalId: externalId}
+
+	return newConnectExecuter(
+		u.coreClient,
+		u.client.UpdateMembership,
+		request,
+	).exec(ctx)
+}
+
+// DeleteMembershipByExternalId deletes a user's membership (identified by external ID) from an organization.
+// cascade, when true, also removes the user from any sub-organizations or nested groups
+// within the organization. Pass false to remove only the direct membership.
+func (u *userService) DeleteMembershipByExternalId(ctx context.Context, organizationId string, externalId string, cascade bool) error {
+	request := &usersv1.DeleteMembershipRequest{
+		OrganizationId: organizationId,
+		Cascade:        &cascade,
+	}
+	request.Identities = &usersv1.DeleteMembershipRequest_ExternalId{ExternalId: externalId}
 
 	_, err := newConnectExecuter(
 		u.coreClient,


### PR DESCRIPTION
## Summary

- Adds 6 new `*ByExternalId` methods to `UserService` (interface + struct in `users.go`):
  - `GetUserByExternalId`
  - `UpdateUserByExternalId`
  - `DeleteUserByExternalId`
  - `CreateMembershipByExternalId`
  - `UpdateMembershipByExternalId`
  - `DeleteMembershipByExternalId`
- Follows the exact same pattern as `GetOrganizationByExternalId` / `UpdateOrganizationByExternalId` in `organization.go` — sets the `oneof identities` field with `*_ExternalId` instead of `*_Id`, using the same `newConnectExecuter` pattern and error handling.
- Adds `TestUserExternalIdOperations` integration test in `test/users_test.go` covering all 6 methods end-to-end: create user with external_id → get → update → create membership → update membership → delete membership → delete user → assert gone.

## Motivation

The backend added REST bindings for these 6 operations in scalekit-inc/scalekit#2283. The Node.js and Python SDKs already expose `*ByExternalId` methods; this PR brings the Go SDK to parity.

## Test plan

- [ ] `go build ./...` — passes (verified locally)
- [ ] `go vet ./...` — passes (verified locally)
- [ ] `TestUserExternalIdOperations` — requires live backend environment; exercise all 6 new methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added external-ID-based user management, including create/read/update/delete operations.
  * Added external-ID-based organization membership management, including create, update, and delete operations.

* **Tests**
  * Added an integration test covering the full user lifecycle driven by an external ID, including membership operations across multiple organizations and final deletion verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->