### PR TITLE
[SK-1276] chore: bump SDK version to 2.7.1

### DIFF
--- a/core.go
+++ b/core.go
@@ -20,7 +20,7 @@ import (
 const (
 	tokenEndpoint      = "oauth/token"
 	jwksEndpoint       = "keys"
-	sdkVersionNumber   = "2.7.0"
+	sdkVersionNumber   = "2.7.1"
 	sdkVersion         = "Scalekit-Go/" + sdkVersionNumber
 	defaultHTTPTimeout = 10 * time.Second
 	maxErrorBodyBytes  = 8 * 1024


### PR DESCRIPTION
## Summary
- Bumps `sdkVersionNumber` in `core.go` from `2.7.0` to `2.7.1`

## Test plan
- [ ] Verify `x-sdk-version` header sent in requests reflects `Scalekit-Go/2.7.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SDK version reported in request headers to 2.7.1.
  * No changes to request behavior, authentication, caching, or other functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->